### PR TITLE
Add Mapbox map with directions

### DIFF
--- a/mapbox_booking_app/lib/config.dart
+++ b/mapbox_booking_app/lib/config.dart
@@ -1,0 +1,1 @@
+const String mapboxAccessToken = 'pk.eyJ1IjoiZ2lic29ucmFwaGFlbCIsImEiOiJjbWNqbm43ODQwNWIwMm1zNXVpOGxjNHJwIn0.iumZsGZJSGBkuw4iB3vRcA';

--- a/mapbox_booking_app/lib/screens/home_screen.dart
+++ b/mapbox_booking_app/lib/screens/home_screen.dart
@@ -1,8 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'map_screen.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  final TextEditingController _fromController = TextEditingController();
+  final TextEditingController _toController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
@@ -28,20 +37,37 @@ class HomeScreen extends StatelessWidget {
             ),
             const SizedBox(height: 32),
             TextField(
-              decoration: InputDecoration(
+              controller: _fromController,
+              decoration: const InputDecoration(
                 labelText: 'From',
                 prefixIcon: Icon(Icons.location_on_outlined),
               ),
             ),
             const SizedBox(height: 16),
             TextField(
-              decoration: InputDecoration(
+              controller: _toController,
+              decoration: const InputDecoration(
                 labelText: 'To',
                 prefixIcon: Icon(Icons.flag_outlined),
               ),
             ),
             const SizedBox(height: 24),
-            ElevatedButton(onPressed: () {}, child: const Text('Select Ride')),
+            ElevatedButton(
+              onPressed: () {
+                if (_fromController.text.isEmpty || _toController.text.isEmpty) {
+                  return;
+                }
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => MapScreen(
+                      origin: _fromController.text,
+                      destination: _toController.text,
+                    ),
+                  ),
+                );
+              },
+              child: const Text('Select Ride'),
+            ),
           ],
         ),
       ),

--- a/mapbox_booking_app/lib/screens/map_screen.dart
+++ b/mapbox_booking_app/lib/screens/map_screen.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:mapbox_gl/mapbox_gl.dart';
+import 'package:http/http.dart' as http;
+
+import '../config.dart';
+
+class MapScreen extends StatefulWidget {
+  final String origin;
+  final String destination;
+
+  const MapScreen({super.key, required this.origin, required this.destination});
+
+  @override
+  State<MapScreen> createState() => _MapScreenState();
+}
+
+class _MapScreenState extends State<MapScreen> {
+  MapboxMapController? mapController;
+  List<LatLng> route = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchRoute();
+  }
+
+  Future<void> _fetchRoute() async {
+    try {
+      final originGeo = await _geocode(widget.origin);
+      final destGeo = await _geocode(widget.destination);
+      if (originGeo == null || destGeo == null) return;
+      final url =
+          'https://api.mapbox.com/directions/v5/mapbox/driving/${originGeo.longitude},${originGeo.latitude};${destGeo.longitude},${destGeo.latitude}?geometries=geojson&access_token=$mapboxAccessToken';
+      final res = await http.get(Uri.parse(url));
+      if (res.statusCode == 200) {
+        final data = jsonDecode(res.body);
+        final coords = data['routes'][0]['geometry']['coordinates'] as List;
+        setState(() {
+          route = coords
+              .map((c) => LatLng(c[1] as double, c[0] as double))
+              .toList();
+        });
+        _addLine();
+      }
+    } catch (_) {}
+  }
+
+  Future<LatLng?> _geocode(String query) async {
+    final url =
+        'https://api.mapbox.com/geocoding/v5/mapbox.places/${Uri.encodeComponent(query)}.json?access_token=$mapboxAccessToken&limit=1';
+    final res = await http.get(Uri.parse(url));
+    if (res.statusCode == 200) {
+      final data = jsonDecode(res.body);
+      final features = data['features'] as List;
+      if (features.isNotEmpty) {
+        final coords = features[0]['center'];
+        return LatLng(coords[1], coords[0]);
+      }
+    }
+    return null;
+  }
+
+  void _onMapCreated(MapboxMapController controller) {
+    mapController = controller;
+    if (route.isNotEmpty) {
+      _addLine();
+    }
+  }
+
+  void _addLine() {
+    if (mapController == null || route.isEmpty) return;
+    mapController!.addLine(LineOptions(
+      geometry: route,
+      lineColor: '#ff9800',
+      lineWidth: 5,
+    ));
+    mapController!.animateCamera(CameraUpdate.newLatLngBounds(
+      LatLngBounds(southwest: route.first, northeast: route.last),
+      left: 40,
+      top: 40,
+      right: 40,
+      bottom: 40,
+    ));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Route')),
+      body: MapboxMap(
+        accessToken: mapboxAccessToken,
+        onMapCreated: _onMapCreated,
+        initialCameraPosition: const CameraPosition(
+          target: LatLng(0, 0),
+          zoom: 2,
+        ),
+      ),
+    );
+  }
+}

--- a/mapbox_booking_app/pubspec.yaml
+++ b/mapbox_booking_app/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   flutter_svg: ^2.0.10
+  mapbox_gl: ^0.16.0
+  http: ^0.13.6
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add Mapbox token configuration
- fetch map routes using Mapbox Directions API
- draw route on new Map screen
- allow users to enter locations and view the route
- include `mapbox_gl` and `http` packages

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686382f04b288321976f531d9d538ac4